### PR TITLE
Add Entity-Relationship Diagram (ERD) for Skill-Sharing Platform

### DIFF
--- a/erDiagram.md
+++ b/erDiagram.md
@@ -1,0 +1,55 @@
+```mermaid
+erDiagram
+    %% Entity: CUSTOMUSER
+    %% Represents a user of the system, whether a teacher or a student
+    CUSTOMUSER {
+        int id PK
+        string full_name
+        string email
+        string password
+        string profile_picture
+        string bio
+        boolean is_teacher
+        boolean is_student
+        datetime date_joined
+    }
+
+    %% Entity: SKILL
+    %% Represents the various skills that can be taught or learned
+    SKILL {
+        int id PK
+        string skill_name
+        string category
+    }
+
+    %% Entity: USERSKILL 
+    %% Junction table that maps users and their associated skills
+    USERSKILL {
+        int id PK
+        int user_id FK
+        int skill_id FK
+        string skill_type
+        string proficiency_level
+    }
+
+    %% Entity: AVAILABILITY 
+    %% Lists the available days and times for a user to teach/learn
+    AVAILABILITY {
+        int id PK
+        int user_id FK
+        string days
+        string time_slots
+    }
+
+    %% Relationships
+    %% CUSTOMUSER to USERSKILL (One-to-Many)
+    %% A user can be linked to multiple skills (teaching or learning)
+    CUSTOMUSER ||--o{ USERSKILL : "has"
+
+    %% SKILL to USERSKILL (One-to-Many)
+    %% One skill can be associated with many users (teaching/learning)
+    SKILL ||--o{ USERSKILL : "containing"
+
+    %% CUSTOMUSER to AVAILABILITY (One-to-One)
+    %% Each user has one availability schedule
+    CUSTOMUSER ||--|{ AVAILABILITY : "has"


### PR DESCRIPTION
## Issue
- Id. : https://github.com/SkillSharing/backEnd/issues/1
- Id. : https://github.com/SkillSharing/backEnd/issues/2

## Pull Request Description
This PR introduces a detailed Entity-Relationship Diagram (ERD) for the Skill-Sharing Platform, documenting the relationships between the CustomUser, Skill, UserSkill, and Availability entities. This diagram improves clarity and understanding for anyone interested in the database design and data flow within the platform.

## Changes Made
- Added a Mermaid.js ER diagram for:
   - CUSTOMUSER: Users who can either be teachers or students.
   - SKILL: The various skills that users can either teach or learn.
   - USERSKILL: The mapping table for users and their associated skills (e.g., whether they are learning or teaching a skill).
   - AVAILABILITY: User availability time slots for teaching or learning.

## Relationship
- CUSTOMUSER to USERSKILL (One-to-Many)
   - A user can be linked to multiple skills (teaching or learning)
- SKILL to USERSKILL (One-to-Many)
   - One skill can be associated with many users (teaching/learning)
- CUSTOMUSER to AVAILABILITY (One-to-One)
   - Each user has one availability schedule


## How to Test or Verify Changes
1. Open the Markdown file or .mmd file in Visual Studio Code (VSCode) or any Mermaid.js-compatible tool (like the Mermaid Live Editor).

2. Use the following workflow to visualize the changes:

   - For VSCode: Ensure the Mermaid plugin is installed, open the ERD Markdown file, and open the Markdown Preview (Ctrl+Shift+P then search for "Markdown: Open Preview").
   - For external preview via Mermaid Live Editor: Copy and paste the code into [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor/).